### PR TITLE
draft - cross account attachment resource

### DIFF
--- a/.changelog/35991.text
+++ b/.changelog/35991.text
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_globalaccelerator_cross_account_attachment
+```

--- a/internal/service/globalaccelerator/cross_account_attachment.go
+++ b/internal/service/globalaccelerator/cross_account_attachment.go
@@ -150,7 +150,7 @@ func (r *resourceCrossAccountAttachment) Read(ctx context.Context, req resource.
 	input := &globalaccelerator.DescribeCrossAccountAttachmentInput{
 		AttachmentArn: aws.String(state.ARN.ValueString()),
 	}
-	out, err := conn.DescribeCrossAccountAttachment(input)
+	out, err := conn.DescribeCrossAccountAttachmentWithContext(ctx, input)
 
 	var nfe *globalaccelerator.AttachmentNotFoundException
 	if errors.As(err, &nfe) {
@@ -263,7 +263,7 @@ func (r *resourceCrossAccountAttachment) ImportState(ctx context.Context, req re
 	conn := r.Meta().GlobalAcceleratorConn(ctx)
 	attachmentArn := req.ID
 
-	output, err := conn.DescribeCrossAccountAttachment(&globalaccelerator.DescribeCrossAccountAttachmentInput{
+	output, err := conn.DescribeCrossAccountAttachmentWithContext(ctx, &globalaccelerator.DescribeCrossAccountAttachmentInput{
 		AttachmentArn: aws.String(attachmentArn),
 	})
 	if err != nil {

--- a/internal/service/globalaccelerator/cross_account_attachment.go
+++ b/internal/service/globalaccelerator/cross_account_attachment.go
@@ -171,7 +171,7 @@ func (r *resourceCrossAccountAttachment) Read(ctx context.Context, req resource.
 	if out.CrossAccountAttachment.LastModifiedTime != nil {
 		state.LastModifiedTime = types.StringValue(out.CrossAccountAttachment.LastModifiedTime.Format(time.RFC3339))
 	}
-	state.Principals = flex.FlattenFrameworkStringList(ctx, out.CrossAccountAttachment.Principals)
+	// state.Principals = flex.FlattenFrameworkStringList(ctx, out.CrossAccountAttachment.Principals)
 
 	resources, errDiags := flattenResources(ctx, out.CrossAccountAttachment.Resources)
 	resp.Diagnostics.Append(errDiags...)
@@ -331,7 +331,7 @@ func expandResources(tfList []ResourceData) []*globalaccelerator.Resource {
 func flattenResources(ctx context.Context, resources []*globalaccelerator.Resource) (types.List, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	if resources == nil || len(resources) == 0 {
+	if len(resources) == 0 {
 		return types.ListNull(ResourceDataElementType), diags
 	}
 

--- a/internal/service/globalaccelerator/cross_account_attachment.go
+++ b/internal/service/globalaccelerator/cross_account_attachment.go
@@ -171,7 +171,8 @@ func (r *resourceCrossAccountAttachment) Read(ctx context.Context, req resource.
 	if out.CrossAccountAttachment.LastModifiedTime != nil {
 		state.LastModifiedTime = types.StringValue(out.CrossAccountAttachment.LastModifiedTime.Format(time.RFC3339))
 	}
-	// state.Principals = flex.FlattenFrameworkStringList(ctx, out.CrossAccountAttachment.Principals)
+
+	state.Principals = flex.FlattenFrameworkStringList(ctx, out.CrossAccountAttachment.Principals)
 
 	resources, errDiags := flattenResources(ctx, out.CrossAccountAttachment.Resources)
 	resp.Diagnostics.Append(errDiags...)

--- a/internal/service/globalaccelerator/cross_account_attachment.go
+++ b/internal/service/globalaccelerator/cross_account_attachment.go
@@ -1,0 +1,534 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package globalaccelerator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/globalaccelerator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource(name="Cross Account Attachment")
+func newResourceCrossAccountAttachment(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceCrossAccountAttachment{}
+
+	r.SetDefaultCreateTimeout(30 * time.Minute)
+	r.SetDefaultUpdateTimeout(30 * time.Minute)
+	r.SetDefaultDeleteTimeout(30 * time.Minute)
+
+	return r, nil
+}
+
+const (
+	ResNameCrossAccountAttachment = "Cross Account Attachment"
+)
+
+type resourceCrossAccountAttachment struct {
+	framework.ResourceWithConfigure
+	framework.WithTimeouts
+}
+
+func (r *resourceCrossAccountAttachment) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_globalaccelerator_cross_account_attachment"
+}
+
+func (r *resourceCrossAccountAttachment) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"attachment_arn": framework.ARNAttributeComputedOnly(),
+			"id":             framework.IDAttribute(),
+			"name": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"principals": schema.ListAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
+			},
+			"resources": schema.ListAttribute{
+				Optional:    true,
+				ElementType: ResourceDataElementType,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
+			},
+			"created_time": schema.StringAttribute{
+				Computed: true,
+			},
+			"last_modified_time": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+	}
+}
+
+func (r *resourceCrossAccountAttachment) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().GlobalAcceleratorConn(ctx)
+
+	var plan resourceCrossAccountAttachmentData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := &globalaccelerator.CreateCrossAccountAttachmentInput{
+		IdempotencyToken: aws.String(id.UniqueId()),
+		Name:             aws.String(plan.Name.ValueString()),
+		Tags:             getTagsIn(ctx),
+	}
+
+	if !plan.Principals.IsNull() {
+		input.Principals = flex.ExpandFrameworkStringList(ctx, plan.Principals)
+	}
+
+	if !plan.Resources.IsNull() {
+		var tfResources []ResourceData
+		diags := plan.Resources.ElementsAs(ctx, &tfResources, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		input.Resources = expandResources(tfResources)
+	}
+
+	out, err := conn.CreateCrossAccountAttachmentWithContext(ctx, input)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.GlobalAccelerator, create.ErrActionCreating, ResNameCrossAccountAttachment, plan.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil || out.CrossAccountAttachment == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.GlobalAccelerator, create.ErrActionCreating, ResNameCrossAccountAttachment, plan.Name.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	plan.ID = flex.StringToFramework(ctx, out.CrossAccountAttachment.AttachmentArn)
+	state := plan
+	state.ARN = flex.StringToFramework(ctx, out.CrossAccountAttachment.AttachmentArn)
+
+	state.CreatedTime = types.StringValue(out.CrossAccountAttachment.CreatedTime.Format(time.RFC3339))
+	if out.CrossAccountAttachment.LastModifiedTime != nil {
+		state.LastModifiedTime = types.StringValue(out.CrossAccountAttachment.LastModifiedTime.Format(time.RFC3339))
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}
+
+func (r *resourceCrossAccountAttachment) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().GlobalAcceleratorConn(ctx)
+
+	var state resourceCrossAccountAttachmentData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := &globalaccelerator.DescribeCrossAccountAttachmentInput{
+		AttachmentArn: aws.String(state.ARN.ValueString()),
+	}
+	out, err := conn.DescribeCrossAccountAttachment(input)
+
+	var nfe *globalaccelerator.AttachmentNotFoundException
+	if errors.As(err, &nfe) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.GlobalAccelerator, create.ErrActionSetting, ResNameCrossAccountAttachment, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.ARN = flex.StringToFramework(ctx, out.CrossAccountAttachment.AttachmentArn)
+	state.Name = flex.StringToFramework(ctx, out.CrossAccountAttachment.Name)
+	state.CreatedTime = types.StringValue(out.CrossAccountAttachment.CreatedTime.Format(time.RFC3339))
+	if out.CrossAccountAttachment.LastModifiedTime != nil {
+		state.LastModifiedTime = types.StringValue(out.CrossAccountAttachment.LastModifiedTime.Format(time.RFC3339))
+	}
+
+	resources, errDiags := flattenResources(ctx, out.CrossAccountAttachment.Resources)
+	resp.Diagnostics.Append(errDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.Resources = resources
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceCrossAccountAttachment) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().GlobalAcceleratorConn(ctx)
+
+	var plan, state resourceCrossAccountAttachmentData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := &globalaccelerator.UpdateCrossAccountAttachmentInput{
+		AttachmentArn: aws.String(state.ARN.ValueString()),
+	}
+
+	var diags diag.Diagnostics
+	if !plan.Principals.Equal(state.Principals) {
+		input.AddPrincipals, input.RemovePrincipals, diags = DiffPrincipals(ctx, state.Principals, plan.Principals)
+		resp.Diagnostics.Append(diags...)
+	}
+
+	if !plan.Resources.Equal(state.Resources) {
+		input.AddResources, input.RemoveResources, diags = DiffResources(ctx, state.Resources, plan.Resources)
+		resp.Diagnostics.Append(diags...)
+	}
+
+	if !plan.Name.Equal(state.Name) {
+		input.Name = aws.String(plan.Name.ValueString())
+	}
+
+	if input.Name != nil || input.AddPrincipals != nil || input.RemovePrincipals != nil || input.AddResources != nil || input.RemoveResources != nil {
+		out, err := conn.UpdateCrossAccountAttachmentWithContext(ctx, input)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error updating CrossAccountAttachment",
+				fmt.Sprintf("Could not update CrossAccountAttachment %s: %s", state.ARN.ValueString(), err),
+			)
+			return
+		}
+
+		state.CreatedTime = types.StringValue(out.CrossAccountAttachment.CreatedTime.Format(time.RFC3339))
+		if out.CrossAccountAttachment.LastModifiedTime != nil {
+			state.LastModifiedTime = types.StringValue(out.CrossAccountAttachment.LastModifiedTime.Format(time.RFC3339))
+		}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceCrossAccountAttachment) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().GlobalAcceleratorConn(ctx)
+
+	var state resourceCrossAccountAttachmentData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := &globalaccelerator.DeleteCrossAccountAttachmentInput{
+		AttachmentArn: aws.String(state.ARN.ValueString()),
+	}
+
+	_, err := conn.DeleteCrossAccountAttachmentWithContext(ctx, input)
+
+	if err != nil {
+		var nfe *globalaccelerator.AttachmentNotFoundException
+		if errors.As(err, &nfe) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error deleting Global Accelerator CrossAccountAttachment",
+			fmt.Sprintf("Could not delete CrossAccountAttachment %s: %s", state.ARN.ValueString(), err),
+		)
+		return
+	}
+}
+
+func (r *resourceCrossAccountAttachment) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	conn := r.Meta().GlobalAcceleratorConn(ctx)
+	attachmentArn := req.ID
+
+	output, err := conn.DescribeCrossAccountAttachment(&globalaccelerator.DescribeCrossAccountAttachmentInput{
+		AttachmentArn: aws.String(attachmentArn),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Error describing CrossAccountAttachment", fmt.Sprintf("Could not describe CrossAccountAttachment with ARN %s: %s", attachmentArn, err))
+		return
+	}
+
+	if output == nil || output.CrossAccountAttachment == nil {
+		resp.Diagnostics.AddError("Error describing CrossAccountAttachment", fmt.Sprintf("CrossAccountAttachment with ARN %s not found", attachmentArn))
+		return
+	}
+
+	var plan resourceCrossAccountAttachmentData
+	plan.ARN = flex.StringToFramework(ctx, output.CrossAccountAttachment.AttachmentArn)
+	plan.ID = flex.StringToFramework(ctx, output.CrossAccountAttachment.AttachmentArn)
+	plan.Name = flex.StringToFramework(ctx, output.CrossAccountAttachment.Name)
+
+	if output.CrossAccountAttachment.Principals != nil {
+		plan.Principals = flex.FlattenFrameworkStringList(ctx, output.CrossAccountAttachment.Principals)
+	}
+	if output.CrossAccountAttachment.Resources != nil {
+		resources, errDiags := flattenResources(ctx, output.CrossAccountAttachment.Resources)
+		if errDiags.HasError() {
+			resp.Diagnostics.Append(errDiags...)
+			return
+		}
+		plan.Resources = resources
+	}
+
+	diags := resp.State.Set(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+}
+
+var ResourceDataElementType = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"endpoint_id": types.StringType,
+		"region":      types.StringType,
+	},
+}
+
+func expandResources(tfList []ResourceData) []*globalaccelerator.Resource {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	apiResources := make([]*globalaccelerator.Resource, len(tfList))
+
+	for i, tfResource := range tfList {
+		apiResource := &globalaccelerator.Resource{
+			EndpointId: aws.String(tfResource.EndpointID.ValueString()),
+		}
+
+		if !tfResource.Region.IsNull() && tfResource.Region.ValueString() != "" {
+			apiResource.Region = aws.String(tfResource.Region.ValueString())
+		}
+
+		apiResources[i] = apiResource
+	}
+
+	return apiResources
+}
+
+func flattenResources(ctx context.Context, resources []*globalaccelerator.Resource) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if resources == nil || len(resources) == 0 {
+		return types.ListNull(ResourceDataElementType), diags
+	}
+
+	elems := []attr.Value{}
+	for _, resource := range resources {
+		endpointID := aws.StringValue(resource.EndpointId)
+		region := ""
+		// Extract the region from the ARN if the endpoint ID is an ARN
+		if strings.HasPrefix(endpointID, "arn:") {
+			parts := strings.Split(endpointID, ":")
+			if len(parts) > 3 {
+				region = parts[3]
+			}
+		}
+
+		obj := map[string]attr.Value{
+			"endpoint_id": types.StringValue(endpointID),
+			"region":      types.StringValue(region),
+		}
+		objVal, d := types.ObjectValue(ResourceDataElementType.AttrTypes, obj)
+		diags.Append(d...)
+
+		elems = append(elems, objVal)
+	}
+
+	listVal, d := types.ListValue(ResourceDataElementType, elems)
+	diags.Append(d...)
+
+	return listVal, diags
+}
+
+func diffResources(ctx context.Context, oldList, newList types.List) (toAdd, toRemove []*globalaccelerator.Resource, diags diag.Diagnostics) {
+	toAdd = []*globalaccelerator.Resource{}
+	toRemove = []*globalaccelerator.Resource{}
+	var oldSlice, newSlice []ResourceData
+
+	oldSlice, diags = convertListToResourceDataSlice(ctx, oldList)
+	if diags.HasError() {
+		return toAdd, toRemove, diags
+	}
+
+	newSlice, diags = convertListToResourceDataSlice(ctx, newList)
+	if diags.HasError() {
+		return toAdd, toRemove, diags
+	}
+
+	addSet, removeSet := diffResourceDataSlices(oldSlice, newSlice)
+
+	for _, r := range addSet {
+		toAdd = append(toAdd, &globalaccelerator.Resource{
+			EndpointId: r.EndpointId,
+			Region:     r.Region,
+		})
+	}
+	for _, r := range removeSet {
+		toRemove = append(toRemove, &globalaccelerator.Resource{
+			EndpointId: r.EndpointId,
+			Region:     r.Region,
+		})
+	}
+
+	return toAdd, toRemove, diags
+}
+
+func convertListToResourceDataSlice(ctx context.Context, resourceList types.List) ([]ResourceData, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var resourceDataSlice []ResourceData
+
+	if !resourceList.IsNull() {
+		diags := resourceList.ElementsAs(ctx, &resourceDataSlice, false)
+		if diags.HasError() {
+			return nil, diags
+		}
+	}
+
+	return resourceDataSlice, diags
+}
+
+func diffResourceDataSlices(oldSlice, newSlice []ResourceData) (toAdd, toRemove []*globalaccelerator.Resource) {
+	toRemoveMap := make(map[string]*globalaccelerator.Resource)
+	toAddMap := make(map[string]*globalaccelerator.Resource)
+
+	for _, oldResource := range oldSlice {
+		key := generateCompositeKey(oldResource.EndpointID.ValueString(), oldResource.Region.ValueString())
+		apiResource := &globalaccelerator.Resource{
+			EndpointId: aws.String(oldResource.EndpointID.ValueString()),
+		}
+		if !oldResource.Region.IsNull() && oldResource.Region.ValueString() != "" {
+			apiResource.Region = aws.String(oldResource.Region.ValueString())
+		}
+		toRemoveMap[key] = apiResource
+	}
+
+	for _, newResource := range newSlice {
+		key := generateCompositeKey(newResource.EndpointID.ValueString(), newResource.Region.ValueString())
+		apiResource := &globalaccelerator.Resource{
+			EndpointId: aws.String(newResource.EndpointID.ValueString()),
+		}
+		if !newResource.Region.IsNull() && newResource.Region.ValueString() != "" {
+			apiResource.Region = aws.String(newResource.Region.ValueString())
+		}
+		if _, found := toRemoveMap[key]; found {
+			delete(toRemoveMap, key)
+		} else {
+			toAddMap[key] = apiResource
+		}
+	}
+
+	for _, resource := range toRemoveMap {
+		toRemove = append(toRemove, resource)
+	}
+	for _, resource := range toAddMap {
+		toAdd = append(toAdd, resource)
+	}
+
+	return toAdd, toRemove
+}
+
+func generateCompositeKey(endpointID, region string) string {
+	if region == "" {
+		region = "NO_REGION" // Special placeholder for resources without region
+	}
+	return endpointID + ":" + region
+}
+
+func diffPrincipals(ctx context.Context, oldList, newList types.List) (toAdd, toRemove []*string, diags diag.Diagnostics) {
+	toAdd = []*string{}
+	toRemove = []*string{}
+	var oldSlice, newSlice []string
+
+	if !oldList.IsNull() {
+		var oldElements []types.String
+		d := oldList.ElementsAs(ctx, &oldElements, false)
+		diags = append(diags, d...)
+		for _, element := range oldElements {
+			oldSlice = append(oldSlice, element.ValueString())
+		}
+	}
+
+	if !newList.IsNull() {
+		var newElements []types.String
+		d := newList.ElementsAs(ctx, &newElements, false)
+		diags = append(diags, d...)
+		for _, element := range newElements {
+			newSlice = append(newSlice, element.ValueString())
+		}
+	}
+
+	addSet, removeSet := diffSlices(oldSlice, newSlice)
+
+	for elem := range addSet {
+		toAdd = append(toAdd, aws.String(elem))
+	}
+
+	for elem := range removeSet {
+		toRemove = append(toRemove, aws.String(elem))
+	}
+
+	return toAdd, toRemove, diags
+}
+
+func diffSlices(oldSlice, newSlice []string) (toAdd, toRemove map[string]struct{}) {
+	toAdd = make(map[string]struct{})
+	toRemove = make(map[string]struct{})
+
+	for _, s := range oldSlice {
+		toRemove[s] = struct{}{}
+	}
+
+	for _, s := range newSlice {
+		if _, found := toRemove[s]; found {
+			delete(toRemove, s)
+			continue
+		}
+		toAdd[s] = struct{}{}
+	}
+
+	return toAdd, toRemove
+}
+
+type resourceCrossAccountAttachmentData struct {
+	ID               types.String `tfsdk:"id"`
+	ARN              types.String `tfsdk:"attachment_arn"`
+	Name             types.String `tfsdk:"name"`
+	Principals       types.List   `tfsdk:"principals"`
+	Resources        types.List   `tfsdk:"resources"`
+	CreatedTime      types.String `tfsdk:"created_time"`
+	LastModifiedTime types.String `tfsdk:"last_modified_time"`
+}
+
+type ResourceData struct {
+	EndpointID types.String `tfsdk:"endpoint_id"`
+	Region     types.String `tfsdk:"region"`
+}

--- a/internal/service/globalaccelerator/cross_account_attachment_test.go
+++ b/internal/service/globalaccelerator/cross_account_attachment_test.go
@@ -411,7 +411,7 @@ func testAccCheckCrossAccountAttachmentDestroy(ctx context.Context) resource.Tes
 				continue
 			}
 
-			_, err := conn.DescribeCrossAccountAttachment(&globalaccelerator.DescribeCrossAccountAttachmentInput{
+			_, err := conn.DescribeCrossAccountAttachmentWithContext(ctx, &globalaccelerator.DescribeCrossAccountAttachmentInput{
 				AttachmentArn: aws.String(rs.Primary.ID),
 			})
 			if err != nil && strings.Contains(err.Error(), "AttachmentNotFoundException") {
@@ -436,7 +436,7 @@ func testAccCheckCrossAccountAttachmentExists(ctx context.Context, resourceName 
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).GlobalAcceleratorConn(ctx)
 
-		output, err := conn.DescribeCrossAccountAttachment(&globalaccelerator.DescribeCrossAccountAttachmentInput{
+		output, err := conn.DescribeCrossAccountAttachmentWithContext(ctx, &globalaccelerator.DescribeCrossAccountAttachmentInput{
 			AttachmentArn: aws.String(rs.Primary.ID),
 		})
 
@@ -457,7 +457,7 @@ func testAccCheckCrossAccountAttachmentExists(ctx context.Context, resourceName 
 func testAccCrossAccountAttachmentConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_globalaccelerator_cross_account_attachment" "test" {
-	  name      = %[1]q
+  name = %[1]q
 }
 `, rName)
 }
@@ -465,7 +465,7 @@ resource "aws_globalaccelerator_cross_account_attachment" "test" {
 func testAccCrossAccountAttachmentConfig_principals(rName string, accountId string) string {
 	return fmt.Sprintf(`
 resource "aws_globalaccelerator_cross_account_attachment" "test" {
-  name      = %[1]q
+  name       = %[1]q
   principals = [%[2]q]
 }
 `, rName, accountId)

--- a/internal/service/globalaccelerator/cross_account_attachment_test.go
+++ b/internal/service/globalaccelerator/cross_account_attachment_test.go
@@ -283,7 +283,6 @@ func TestAccGlobalAcceleratorCrossAccountAttachment_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			// acctest.PreCheckPartitionHasService(t, "aws_globalaccelerator_cross_account_attachment")
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, "aws_globalaccelerator_cross_account_attachment"),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -358,18 +357,6 @@ func TestAccGlobalAcceleratorCrossAccountAttachment_resources(t *testing.T) {
 		CheckDestroy:             testAccCheckCrossAccountAttachmentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-
-				Config: testAccCrossAccountAttachmentConfig_resources(rName, []globalaccelerator_test.ResourceData{
-					{EndpointID: types.StringValue(endpointID), Region: types.StringValue(region)},
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "resources.*", map[string]string{
-						"endpoint_id": endpointID,
-						"region":      region,
-					}),
-				),
-			},
-			{
 				Config: testAccCrossAccountAttachmentConfig_resources(rName, []globalaccelerator_test.ResourceData{
 					{EndpointID: types.StringValue(endpointID), Region: types.StringValue(region)},
 					{EndpointID: types.StringValue(endpointID2), Region: types.StringValue(alternateRegion)},
@@ -398,7 +385,6 @@ func TestAccGlobalAcceleratorCrossAccountAttachment_disappears(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			// acctest.PreCheckPartitionHasService(t, "aws_globalaccelerator_cross_account_attachment")
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, "aws_globalaccelerator_cross_account_attachment"),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/globalaccelerator/cross_account_attachment_test.go
+++ b/internal/service/globalaccelerator/cross_account_attachment_test.go
@@ -1,0 +1,476 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package globalaccelerator_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/globalaccelerator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	globalaccelerator_test "github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator"
+)
+
+func generateAccountID() string {
+	source := rand.NewSource(42)
+	rand := rand.New(source)
+
+	accountID := ""
+	for i := 0; i < 12; i++ {
+		digit := rand.Intn(10)
+		accountID += strconv.Itoa(digit)
+	}
+	return accountID
+}
+
+func TestExpandResources(t *testing.T) {
+	cases := []struct {
+		Input          []globalaccelerator_test.ResourceData
+		ExpectedOutput []*globalaccelerator.Resource
+	}{
+		{
+			Input:          []globalaccelerator_test.ResourceData{},
+			ExpectedOutput: nil,
+		},
+		{
+			Input: []globalaccelerator_test.ResourceData{
+				{
+					EndpointID: types.StringValue("endpoint-1"),
+					Region:     types.StringValue("us-west-2"),
+				},
+				{
+					EndpointID: types.StringValue("endpoint-2"),
+					Region:     types.StringValue(""),
+				},
+			},
+			ExpectedOutput: []*globalaccelerator.Resource{
+				{
+					EndpointId: aws.String("endpoint-1"),
+					Region:     aws.String("us-west-2"),
+				},
+				{
+					EndpointId: aws.String("endpoint-2"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		output := globalaccelerator_test.ExpandResources(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("bad: expected %v, got %v", tc.ExpectedOutput, output)
+		}
+	}
+}
+
+func TestFlattenResources(t *testing.T) {
+	elem := globalaccelerator_test.ResourceDataElementType
+
+	endpoint1, _ := types.ObjectValue(elem.AttrTypes, map[string]attr.Value{
+		"endpoint_id": types.StringValue("arn:aws:ec2:us-west-2:171405876253:elastic-ip/eipalloc-1234567890abcdef0"),
+		"region":      types.StringValue("us-west-2"),
+	})
+
+	expectedList, _ := types.ListValue(elem, []attr.Value{endpoint1})
+
+	testCases := []struct {
+		Name     string
+		Input    []*globalaccelerator.Resource
+		Expected types.List
+	}{
+		{
+			Name:     "empty input",
+			Input:    []*globalaccelerator.Resource{},
+			Expected: types.ListNull(elem),
+		},
+		{
+			Name: "non-empty input",
+			Input: []*globalaccelerator.Resource{
+				{
+					EndpointId: aws.String("arn:aws:ec2:us-west-2:171405876253:elastic-ip/eipalloc-1234567890abcdef0"),
+					Region:     aws.String("us-west-2"),
+				},
+			},
+			Expected: expectedList,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			ctx := context.Background()
+			output, err := globalaccelerator_test.FlattenResources(ctx, tc.Input)
+
+			if err != nil {
+				t.Fatalf("flattenResources() error = %v, wantErr %v", err, nil)
+			}
+
+			if !reflect.DeepEqual(output, tc.Expected) {
+				t.Errorf("flattenResources() got = %v, want %v", output, tc.Expected)
+			}
+		})
+	}
+}
+
+func TestDiffResources(t *testing.T) {
+	ctx := context.Background()
+	elem := globalaccelerator_test.ResourceDataElementType
+
+	endpoint1Object, _ := types.ObjectValue(elem.AttrTypes, map[string]attr.Value{
+		"endpoint_id": types.StringValue("endpoint-1"),
+		"region":      types.StringValue("us-west-2"),
+	})
+	endpoint2Object, _ := types.ObjectValue(elem.AttrTypes, map[string]attr.Value{
+		"endpoint_id": types.StringValue("endpoint-2"),
+		"region":      types.StringValue("us-east-1"),
+	})
+
+	expectedResource1 := &globalaccelerator.Resource{
+		EndpointId: aws.String("endpoint-1"),
+		Region:     aws.String("us-west-2"),
+	}
+	expectedResource2 := &globalaccelerator.Resource{
+		EndpointId: aws.String("endpoint-2"),
+		Region:     aws.String("us-east-1"),
+	}
+
+	cases := []struct {
+		Name             string
+		OldList          types.List
+		NewList          types.List
+		ExpectedToAdd    []*globalaccelerator.Resource
+		ExpectedToRemove []*globalaccelerator.Resource
+	}{
+		{
+			Name:             "EmptyLists",
+			OldList:          types.ListNull(elem),
+			NewList:          types.ListNull(elem),
+			ExpectedToAdd:    []*globalaccelerator.Resource{},
+			ExpectedToRemove: []*globalaccelerator.Resource{},
+		},
+		{
+			Name:    "Resource to add",
+			OldList: types.ListValueMust(elem, []attr.Value{endpoint1Object}),
+			NewList: types.ListValueMust(elem, []attr.Value{endpoint1Object, endpoint2Object}),
+			ExpectedToAdd: []*globalaccelerator.Resource{
+				expectedResource2,
+			},
+			ExpectedToRemove: []*globalaccelerator.Resource{},
+		},
+		{
+			Name:          "Resource to remove",
+			OldList:       types.ListValueMust(elem, []attr.Value{endpoint1Object, endpoint2Object}),
+			NewList:       types.ListValueMust(elem, []attr.Value{endpoint1Object}),
+			ExpectedToAdd: []*globalaccelerator.Resource{},
+			ExpectedToRemove: []*globalaccelerator.Resource{
+				expectedResource2,
+			},
+		},
+		{
+			Name:    "Resource to add and remove",
+			OldList: types.ListValueMust(elem, []attr.Value{endpoint1Object}),
+			NewList: types.ListValueMust(elem, []attr.Value{endpoint2Object}),
+			ExpectedToAdd: []*globalaccelerator.Resource{
+				expectedResource2,
+			},
+			ExpectedToRemove: []*globalaccelerator.Resource{
+				expectedResource1,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			toAdd, toRemove, _ := globalaccelerator_test.DiffResources(ctx, tc.OldList, tc.NewList)
+
+			if !reflect.DeepEqual(toAdd, tc.ExpectedToAdd) {
+				t.Errorf("expected to add: %#v, got: %#v", tc.ExpectedToAdd, toAdd)
+			}
+
+			if !reflect.DeepEqual(toRemove, tc.ExpectedToRemove) {
+				t.Errorf("expected to remove: %#v, got: %#v", tc.ExpectedToRemove, toRemove)
+			}
+		})
+	}
+}
+
+func TestDiffPrincipals(t *testing.T) {
+	ctx := context.Background()
+
+	elemType := types.StringType
+
+	principal1 := types.StringValue("principal-1")
+	principal2 := types.StringValue("principal-2")
+
+	oldList, _ := types.ListValue(elemType, []attr.Value{principal1})
+	newList, _ := types.ListValue(elemType, []attr.Value{principal2})
+
+	cases := []struct {
+		Name             string
+		OldList          types.List
+		NewList          types.List
+		ExpectedToAdd    []*string
+		ExpectedToRemove []*string
+	}{
+		{
+			Name:             "EmptyLists",
+			OldList:          types.ListNull(elemType),
+			NewList:          types.ListNull(elemType),
+			ExpectedToAdd:    []*string{},
+			ExpectedToRemove: []*string{},
+		},
+		{
+			Name:             "NonEmptyLists",
+			OldList:          oldList,
+			NewList:          newList,
+			ExpectedToAdd:    []*string{aws.String("principal-2")},
+			ExpectedToRemove: []*string{aws.String("principal-1")},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			toAdd, toRemove, _ := globalaccelerator_test.DiffPrincipals(ctx, tc.OldList, tc.NewList)
+
+			if !reflect.DeepEqual(toAdd, tc.ExpectedToAdd) {
+				t.Errorf("expected to add: %#v, got: %#v", tc.ExpectedToAdd, toAdd)
+			}
+
+			if !reflect.DeepEqual(toRemove, tc.ExpectedToRemove) {
+				t.Errorf("expected to remove: %#v, got: %#v", tc.ExpectedToRemove, toRemove)
+			}
+		})
+	}
+}
+
+func TestAccGlobalAcceleratorCrossAccountAttachment_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_globalaccelerator_cross_account_attachment.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	var v *globalaccelerator.DescribeCrossAccountAttachmentOutput
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			// acctest.PreCheckPartitionHasService(t, "aws_globalaccelerator_cross_account_attachment")
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, "aws_globalaccelerator_cross_account_attachment"),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCrossAccountAttachmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCrossAccountAttachmentConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCrossAccountAttachmentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+func TestAccGlobalAcceleratorCrossAccountAttachment_principals(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_globalaccelerator_cross_account_attachment.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	var v *globalaccelerator.DescribeCrossAccountAttachmentOutput
+	accountId := generateAccountID()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, "aws_globalaccelerator_cross_account_attachment"),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCrossAccountAttachmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCrossAccountAttachmentConfig_principals(rName, accountId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCrossAccountAttachmentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckTypeSetElemAttr(resourceName, "principals.*", accountId),
+					resource.TestCheckResourceAttrSet(resourceName, "created_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_modified_time"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccGlobalAcceleratorCrossAccountAttachment_resources(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_globalaccelerator_cross_account_attachment.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	endpoint1 := "arn:aws:ec2:us-west-2:171405876253:elastic-ip/eipalloc-1234567890abcdef0"
+	endpoint2 := "arn:aws:ec2:us-east-1:171405876253:elastic-ip/eipalloc-1234567890abcdef1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, "aws_globalaccelerator_cross_account_attachment"),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCrossAccountAttachmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+
+				Config: testAccCrossAccountAttachmentConfig_resources(rName, []globalaccelerator_test.ResourceData{
+					{EndpointID: types.StringValue(endpoint1), Region: types.StringValue(acctest.Region())},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "resources.*", map[string]string{
+						"endpoint_id": endpoint1,
+						"region":      acctest.Region(),
+					}),
+				),
+			},
+			{
+				Config: testAccCrossAccountAttachmentConfig_resources(rName, []globalaccelerator_test.ResourceData{
+					{EndpointID: types.StringValue(endpoint1), Region: types.StringValue(acctest.Region())},
+					{EndpointID: types.StringValue(endpoint2), Region: types.StringValue(acctest.AlternateRegion())},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "resources.*", map[string]string{
+						"endpoint_id": endpoint1,
+						"region":      acctest.Region(),
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "resources.*", map[string]string{
+						"endpoint_id": endpoint2,
+						"region":      acctest.AlternateRegion(),
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGlobalAcceleratorCrossAccountAttachment_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_globalaccelerator_cross_account_attachment.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	var v *globalaccelerator.DescribeCrossAccountAttachmentOutput
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			// acctest.PreCheckPartitionHasService(t, "aws_globalaccelerator_cross_account_attachment")
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, "aws_globalaccelerator_cross_account_attachment"),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCrossAccountAttachmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCrossAccountAttachmentConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCrossAccountAttachmentExists(ctx, resourceName, &v),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, globalaccelerator_test.ResourceCrossAccountAttachment, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckCrossAccountAttachmentDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).GlobalAcceleratorConn(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_globalaccelerator_cross_account_attachment" {
+				continue
+			}
+
+			_, err := conn.DescribeCrossAccountAttachment(&globalaccelerator.DescribeCrossAccountAttachmentInput{
+				AttachmentArn: aws.String(rs.Primary.ID),
+			})
+			if err != nil && strings.Contains(err.Error(), "AttachmentNotFoundException") {
+				return nil
+			} else if err != nil {
+				return fmt.Errorf("error checking if Global Accelerator Cross Account Attachment %s still exists: %s", rs.Primary.ID, err)
+			}
+
+			return fmt.Errorf("Global Accelerator Cross Account Attachment %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckCrossAccountAttachmentExists(ctx context.Context, resourceName string, v **globalaccelerator.DescribeCrossAccountAttachmentOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).GlobalAcceleratorConn(ctx)
+
+		output, err := conn.DescribeCrossAccountAttachment(&globalaccelerator.DescribeCrossAccountAttachmentInput{
+			AttachmentArn: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || output.CrossAccountAttachment == nil {
+			return fmt.Errorf("Global Accelerator Cross Account Attachment %s does not exist", rs.Primary.ID)
+		}
+
+		*v = output
+
+		return nil
+	}
+}
+
+func testAccCrossAccountAttachmentConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_globalaccelerator_cross_account_attachment" "test" {
+	  name      = %[1]q
+}
+`, rName)
+}
+
+func testAccCrossAccountAttachmentConfig_principals(rName string, accountId string) string {
+	return fmt.Sprintf(`
+resource "aws_globalaccelerator_cross_account_attachment" "test" {
+  name      = %[1]q
+  principals = [%[2]q]
+}
+`, rName, accountId)
+}
+
+func testAccCrossAccountAttachmentConfig_resources(rName string, resources []globalaccelerator_test.ResourceData) string {
+	var resourcesStr []string
+	for _, r := range resources {
+		resourcesStr = append(resourcesStr, fmt.Sprintf(`{ endpoint_id = "%s", region = "%s" }`, r.EndpointID.ValueString(), r.Region.ValueString()))
+	}
+	return fmt.Sprintf(`
+resource "aws_globalaccelerator_cross_account_attachment" "test" {
+  name      = "%s"
+  resources = [%s]
+}
+`, rName, strings.Join(resourcesStr, ", "))
+}

--- a/internal/service/globalaccelerator/exports_test.go
+++ b/internal/service/globalaccelerator/exports_test.go
@@ -1,0 +1,13 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package globalaccelerator
+
+// Exports for use in tests only.
+var (
+	ExpandResources                = expandResources
+	FlattenResources               = flattenResources
+	DiffResources                  = diffResources
+	DiffPrincipals                 = diffPrincipals
+	ResourceCrossAccountAttachment = newResourceCrossAccountAttachment
+)

--- a/internal/service/globalaccelerator/service_package_gen.go
+++ b/internal/service/globalaccelerator/service_package_gen.go
@@ -21,7 +21,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
-	return []*types.ServicePackageFrameworkResource{}
+	return []*types.ServicePackageFrameworkResource{
+		{
+			Factory: newResourceCrossAccountAttachment,
+			Name:    "Cross Account Attachment",
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {

--- a/website/docs/r/globalaccelerator_cross_account_attachment.html.markdown
+++ b/website/docs/r/globalaccelerator_cross_account_attachment.html.markdown
@@ -1,0 +1,80 @@
+---
+subcategory: "Global Accelerator"
+layout: "aws"
+page_title: "AWS: aws_globalaccelerator_cross_account_attachment"
+description: |-
+  Terraform resource for managing an AWS Global Accelerator Cross Account Attachment.
+---
+
+# Resource: aws_globalaccelerator_cross_account_attachment
+
+Terraform resource for managing an AWS Global Accelerator Cross Account Attachment.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_globalaccelerator_cross_account_attachment" "example" {
+  name = "example-cross-account-attachment"
+}
+```
+
+### Usage with Optional Arguments 
+
+```terraform
+resource "aws_globalaccelerator_cross_account_attachment" "example" {
+  name       = "example-cross-account-attachment"
+  principals = ["123456789012"]
+  resources = [
+    { endpoint_id = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188", region = "us-west-2" },
+    { endpoint_id = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-other-load-balancer/50dc6c495c0c9189", region = "us-east-1" }
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Name of the Cross Account Attachment.
+
+The following arguments are optional:
+
+* `principals` - (Optional) List of AWS account IDs that are allowed to associate resources with the accelerator.
+* `resources` - (Optional) List of resources to be associated with the accelerator. Each resource is specified as a map with keys `endpoint_id` and `region.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the Cross Account Attachment. 
+* `id` - ID of the Cross Account Attachment.
+* `created_time` - Creation Time when the Cross Account Attachment.
+* `last_modified_time` - Last modified time of the Cross Account Attachment. 
+* 
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `30m`)
+* `update` - (Default `30m`)
+* `delete` - (Default `30m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Global Accelerator Cross Account Attachment using the `example_id_arg`. For example:
+
+```terraform
+import {
+  to = aws_globalaccelerator_cross_account_attachment.example
+  id = "cross_account_attachment-id-12345678"
+}
+```
+
+Using `terraform import`, import Global Accelerator Cross Account Attachment using the `example_id_arg`. For example:
+
+```console
+% terraform import aws_globalaccelerator_cross_account_attachment.example cross_account_attachment-id-12345678
+```

--- a/website/docs/r/globalaccelerator_cross_account_attachment.html.markdown
+++ b/website/docs/r/globalaccelerator_cross_account_attachment.html.markdown
@@ -42,7 +42,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `principals` - (Optional) List of AWS account IDs that are allowed to associate resources with the accelerator.
-* `resources` - (Optional) List of resources to be associated with the accelerator. Each resource is specified as a map with keys `endpoint_id` and `region.
+* `resources` - (Optional) List of resources to be associated with the accelerator. Each resource is specified as a map with keys `endpoint_id` and `region`. The `region` field is optional. 
 
 ## Attribute Reference
 
@@ -52,7 +52,6 @@ This resource exports the following attributes in addition to the arguments abov
 * `id` - ID of the Cross Account Attachment.
 * `created_time` - Creation Time when the Cross Account Attachment.
 * `last_modified_time` - Last modified time of the Cross Account Attachment. 
-* 
 
 ## Timeouts
 
@@ -69,12 +68,12 @@ In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashico
 ```terraform
 import {
   to = aws_globalaccelerator_cross_account_attachment.example
-  id = "cross_account_attachment-id-12345678"
+  id = "arn:aws:globalaccelerator::012345678910:attachment/01234567-abcd-8910-efgh-123456789012"
 }
 ```
 
 Using `terraform import`, import Global Accelerator Cross Account Attachment using the `example_id_arg`. For example:
 
 ```console
-% terraform import aws_globalaccelerator_cross_account_attachment.example cross_account_attachment-id-12345678
+% terraform import arn:aws:globalaccelerator::012345678910:attachment/01234567-abcd-8910-efgh-123456789012
 ```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Draft for cross account attachment implementation 

<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
Passing acceptance tests 
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/globalaccelerator/... -v -count 1 -parallel 20 -run='TestAccGlobalAcceleratorCrossAccountAttachment_basic'  -timeout 360m
=== RUN   TestAccGlobalAcceleratorCrossAccountAttachment_basic
=== PAUSE TestAccGlobalAcceleratorCrossAccountAttachment_basic
=== CONT  TestAccGlobalAcceleratorCrossAccountAttachment_basic
--- PASS: TestAccGlobalAcceleratorCrossAccountAttachment_basic (13.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator  19.684s

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/globalaccelerator/... -v -count 1 -parallel 20 -run='TestAccGlobalAcceleratorCrossAccountAttachment_principals'  -timeout 360m
=== RUN   TestAccGlobalAcceleratorCrossAccountAttachment_principals
=== PAUSE TestAccGlobalAcceleratorCrossAccountAttachment_principals
=== CONT  TestAccGlobalAcceleratorCrossAccountAttachment_principals
--- PASS: TestAccGlobalAcceleratorCrossAccountAttachment_principals (13.46s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator  19.293s

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/globalaccelerator/... -v -count 1 -parallel 20 -run='TestAccGlobalAcceleratorCrossAccountAttachment_resources'  -timeout 360m
=== RUN   TestAccGlobalAcceleratorCrossAccountAttachment_resources
=== PAUSE TestAccGlobalAcceleratorCrossAccountAttachment_resources
=== CONT  TestAccGlobalAcceleratorCrossAccountAttachment_resources
--- PASS: TestAccGlobalAcceleratorCrossAccountAttachment_resources (18.48s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator  24.444s

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/globalaccelerator/... -v -count 1 -parallel 20 -run='TestAccGlobalAcceleratorCrossAccountAttachment_disappears'  -timeout 360m
=== RUN   TestAccGlobalAcceleratorCrossAccountAttachment_disappears
=== PAUSE TestAccGlobalAcceleratorCrossAccountAttachment_disappears
=== CONT  TestAccGlobalAcceleratorCrossAccountAttachment_disappears
--- PASS: TestAccGlobalAcceleratorCrossAccountAttachment_disappears (12.10s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator  18.071s
```